### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -33,7 +33,7 @@ jobs:
           images: ghcr.io/naev/${{ matrix.imagename }}
 
       - name: Build and push
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         id: docker_build
         with:
           name: ghcr.io/naev/${{ matrix.imagename }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore